### PR TITLE
Allow not enforced in add fk statement

### DIFF
--- a/pegjs/transactsql.pegjs
+++ b/pegjs/transactsql.pegjs
@@ -1106,7 +1106,8 @@ create_constraint_foreign
   p:('FOREIGN KEY'i) __
   i:column? __
   de:cte_column_definition __
-  id:reference_definition? {
+  id:reference_definition? __
+  not_enforced: KW_NOT_ENFORCED? {
     return {
         constraint: kc && kc.constraint,
         definition: de,
@@ -1114,7 +1115,8 @@ create_constraint_foreign
         keyword: kc && kc.keyword,
         index: i,
         resource: 'constraint',
-        reference_definition: id
+        reference_definition: id,
+        enforced: not_enforced
       }
   }
 
@@ -3136,6 +3138,7 @@ KW_SPATIAL  = "SPATIAL"i  !ident_start { return 'SPATIAL'; }
 KW_UNIQUE     = "UNIQUE"i  !ident_start { return 'UNIQUE'; }
 KW_CLUSTERED     = "CLUSTERED"i  !ident_start { return 'CLUSTERED'; }
 KW_NONCLUSTERED  = "NONCLUSTERED"i  !ident_start { return 'NONCLUSTERED'; }
+KW_NOT_ENFORCED = "NOT ENFORCED"i !ident_start { return 'NOT ENFORCED'; }
 KW_KEY_BLOCK_SIZE = "KEY_BLOCK_SIZE"i !ident_start { return 'KEY_BLOCK_SIZE'; }
 KW_COMMENT     = "COMMENT"i  !ident_start { return 'COMMENT'; }
 KW_CONSTRAINT  = "CONSTRAINT"i  !ident_start { return 'CONSTRAINT'; }

--- a/test/transactsql.spec.js
+++ b/test/transactsql.spec.js
@@ -354,6 +354,10 @@ describe('transactsql', () => {
       expect(getParsedSql(sql)).to.be.equal("IF DATENAME([weekday], GETDATE()) IN (N'Saturday', N'Sunday') SELECT 'Weekend'; ELSE SELECT 'Weekday';")
     })
   })
+  it('should support NOT ENFORCED in query', () => {
+    const notEnforcedSQL = `ALTER TABLE [Orders] ADD CONSTRAINT [FK_Orders_Customers] FOREIGN KEY ([CustomerID]) REFERENCES [Customers] ([CustomerID]) NOT ENFORCED`
+    expect(getParsedSql(notEnforcedSQL)).to.be.equal(notEnforcedSQL)
+  })
   describe('from values', () => {
     it('should support from values', () => {
       const sql = `select * from (values (0, 0), (1, null), (null, 2), (3, 4)) as t(a,b)`


### PR DESCRIPTION
To support queries that may have `NOT ENFORCED` in them. For example:
```
  ALTER TABLE Orders
  ADD CONSTRAINT FK_Orders_Customers
  FOREIGN KEY (CustomerID)
  REFERENCES Customers (CustomerID)
  NOT ENFORCED;
```